### PR TITLE
Use a better RNG for better shuffle/smart playlists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,9 @@ if (PROFILE)
 endif()
 
 # optionally enable better RNG
-option(WANT_SRANDOM "Enable srandom for better RNG by setting POSIX_C_SOURCE" OFF)
-if (WANT_SRANDOM)
-    add_definitions(-D__POSIX_C_SOURCE=1)
+option(WANT_MT19937_RANDOM "Enable mt19936 RNG for better shuffle etc" OFF)
+if (WANT_MT19937_RANDOM)
+    add_definitions(-DMT19937_RANDOM=1)
 endif()
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,12 @@ if (PROFILE)
     message("Adding profiling code.")
 endif()
 
+# optionally enable better RNG
+option(WANT_SRANDOM "Enable srandom for better RNG by setting POSIX_C_SOURCE" OFF)
+if (WANT_SRANDOM)
+    add_definitions(-D__POSIX_C_SOURCE=1)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(po)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,10 +146,10 @@ if (PROFILE)
     message("Adding profiling code.")
 endif()
 
-# optionally enable better RNG
-option(WANT_MT19937_RANDOM "Enable mt19936 RNG for better shuffle etc" OFF)
-if (WANT_MT19937_RANDOM)
-    add_definitions(-DMT19937_RANDOM=1)
+# enable better RNG
+option(CXX11_RNG "Enable CXX11 compliant random generator for better RNG" ON)
+if (CXX11_RNG)
+    add_definitions(-DCXX11_RNG=1)
 endif()
 
 add_subdirectory(src)

--- a/src/misc/Utils.cpp
+++ b/src/misc/Utils.cpp
@@ -35,7 +35,7 @@
 
 namespace Guayadeque {
 
-#ifdef MT19937_RANDOM
+#ifdef CXX11_RNG
 std::mt19937 rng_generator;
 #endif
 

--- a/src/misc/Utils.cpp
+++ b/src/misc/Utils.cpp
@@ -35,6 +35,10 @@
 
 namespace Guayadeque {
 
+#ifdef MT19937_RANDOM
+std::mt19937 rng_generator;
+#endif
+
 // -------------------------------------------------------------------------------- //
 bool IsColorDark( const wxColour &color )
 {

--- a/src/misc/Utils.h
+++ b/src/misc/Utils.h
@@ -20,7 +20,7 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
-#ifdef MT19937_RANDOM
+#ifdef CXX11_RNG
 #include <random>
 #endif
 
@@ -47,7 +47,7 @@ namespace Guayadeque {
     #define guLogError      wxLogError
 #endif
 
-#ifdef MT19937_RANDOM
+#ifdef CXX11_RNG
 
 extern std::mt19937 rng_generator;
 

--- a/src/misc/Utils.h
+++ b/src/misc/Utils.h
@@ -43,8 +43,13 @@ namespace Guayadeque {
     #define guLogError      wxLogError
 #endif
 
+#ifdef __POSIX_C_SOURCE
+#define guRandomInit() (srandom( time( NULL ) ))
+#define guRandom(x) (random() % x)
+#else
 #define guRandomInit() (srand( time( NULL ) ))
 #define guRandom(x) (rand() % x)
+#endif
 
 #define guDEFAULT_BROWSER_USER_AGENT    wxT( "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/55.0.2883.87 Chrome/55.0.2883.87 Safari/537.36" )
 

--- a/src/misc/Utils.h
+++ b/src/misc/Utils.h
@@ -20,6 +20,10 @@
 #ifndef _UTILS_H
 #define _UTILS_H
 
+#ifdef MT19937_RANDOM
+#include <random>
+#endif
+
 #include <wx/wx.h>
 #include <wx/file.h>
 #include <wx/wfstream.h>
@@ -43,9 +47,17 @@ namespace Guayadeque {
     #define guLogError      wxLogError
 #endif
 
-#ifdef __POSIX_C_SOURCE
-#define guRandomInit() (srandom( time( NULL ) ))
-#define guRandom(x) (random() % x)
+#ifdef MT19937_RANDOM
+
+extern std::mt19937 rng_generator;
+
+void inline guRandomInit(void) {
+    rng_generator.seed( time( NULL ) );
+}
+
+std::uint_fast32_t inline guRandom(std::uint_fast32_t x) {
+    return (rng_generator() % x);
+}
 #else
 #define guRandomInit() (srand( time( NULL ) ))
 #define guRandom(x) (rand() % x)


### PR DESCRIPTION
  The default generator guayadeque has used, rand() does not provide
  a good numeric distribution, and the quality of playlist shuffle and
  dynamic playlists suffers as a result.  Add optional use of the
  random() RNG instead.  (This could be made automatic, but I figure it
  should be manual for at least a time, in case someone somehow is
  running guayadeque on a system that can't satisfy POSIX_C_SOURCE, and
  it does change the observed behavior of the RNG.)